### PR TITLE
remove duplicate type declaration (HeaderField)

### DIFF
--- a/src/ic_loot_rs/lib.rs
+++ b/src/ic_loot_rs/lib.rs
@@ -798,8 +798,6 @@ fn export_candid() -> String {
 //     ░  ░ ░            ░       ░      ░
 //        ░            ░
 
-type HeaderField = record { text; text; };
-
 type HttpRequest = record {
     method: text;
     url: text;


### PR DESCRIPTION
it's already declared above in same file https://github.com/dscvr-one/ic-drip/blob/a8aec9d794c3145a8694b1a0c32797d2db8f27fc/src/ic_loot_rs/lib.rs#L650